### PR TITLE
Updated Dockerfile a little bit.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,8 @@
 FROM alpine
 MAINTAINER Jean Blanchard <jean@blanchard.io>
 
-# Install cURL
-RUN apk add --update curl
-
-# Java Version
-ENV JAVA_VERSION_MAJOR 8
-ENV JAVA_VERSION_MINOR 45
-ENV JAVA_VERSION_BUILD 14
-ENV JAVA_PACKAGE       server-jre
-
 # Download and install glibc
-RUN apk add --update curl &&\
+RUN apk add --update curl && \
   curl -o glibc-2.21-r2.apk "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" && \
   apk add --allow-untrusted glibc-2.21-r2.apk && \
   curl -o glibc-bin-2.21-r2.apk "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-bin-2.21-r2.apk" && \


### PR DESCRIPTION
Not sure if there was a reason for the first 'apk add --update curl' line since it is in the big single step block as well... It added an extra docker layer that wasn't needed, so pulled it.  Also, not sure why the Java environment variables were being set when the image doesn't contain any Java, so I pulled those out as well.

These changes shave about 2.5 MB off the image size as well.
