### PR TITLE
Update to glibc 2.25-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 MAINTAINER Jean Blanchard <jean@blanchard.io>
 
-ENV GLIBC_VERSION 2.23-r3
+ENV GLIBC_VERSION 2.25-r0
 
 # Download and install glibc
 RUN apk add --update curl && \


### PR DESCRIPTION
2.25 fix some security problems. see https://github.com/sgerrand/alpine-pkg-glibc/issues/35