### PR TITLE
Add badges of 3.8 and 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Basic [Docker](https://www.docker.com/) image based on [Alpine Linux](http://alpinelinux.org/), with [glibc](https://github.com/sgerrand/alpine-pkg-glibc).
 
 ### Tags
-
-* [`latest` `3.7`](https://github.com/jeanblanchard/docker-alpine-glibc/blob/master/Dockerfile) [![](https://images.microbadger.com/badges/image/jeanblanchard/alpine-glibc.svg)](https://microbadger.com/images/jeanblanchard/alpine-glibc "Get your own image badge on microbadger.com")
+* `latest` `3.9` [![](https://images.microbadger.com/badges/image/jeanblanchard/alpine-glibc:3.9.svg)](https://microbadger.com/images/jeanblanchard/alpine-glibc:3.9 "Get your own image badge on microbadger.com")
+* `3.8` [![](https://images.microbadger.com/badges/image/jeanblanchard/alpine-glibc:3.8.svg)](https://microbadger.com/images/jeanblanchard/alpine-glibc:3.8 "Get your own image badge on microbadger.com")
+* `3.7` [![](https://images.microbadger.com/badges/image/jeanblanchard/alpine-glibc:3.7.svg)](https://microbadger.com/images/jeanblanchard/alpine-glibc:3.7 "Get your own image badge on microbadger.com")
 * [`3.6`](https://github.com/jeanblanchard/docker-alpine-glibc/blob/alpine3.6/Dockerfile) [![](https://images.microbadger.com/badges/image/jeanblanchard/alpine-glibc:3.6.svg)](https://microbadger.com/images/jeanblanchard/alpine-glibc:3.6 "Get your own image badge on microbadger.com")
 * [`3.5`](https://github.com/jeanblanchard/docker-alpine-glibc/blob/alpine3.5/Dockerfile) [![](https://images.microbadger.com/badges/image/jeanblanchard/alpine-glibc:3.5.svg)](https://microbadger.com/images/jeanblanchard/alpine-glibc:3.5 "Get your own image badge on microbadger.com")


### PR DESCRIPTION
Hi! Thank you for useful Docker image!

## Added
I added badges for `3.9` and `3.8` and updated the badge link of `3.7` because `3.7` is no longer latest.
